### PR TITLE
Chapter 2: Adding web-based display

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -1,7 +1,11 @@
 package controller
 
 import (
+	"encoding/json"
 	"testing"
+
+	"github.com/nunnatsa/piHatDraw/notifier"
+	"github.com/nunnatsa/piHatDraw/webapp"
 
 	"github.com/nunnatsa/piHatDraw/hat"
 
@@ -12,10 +16,19 @@ func TestControllerStart(t *testing.T) {
 	s := state.NewState()
 	je := make(chan hat.Event)
 	se := make(chan hat.DisplayMessage)
+	n := notifier.NewNotifier()
+	ce := make(chan webapp.ClientEvent)
+
 	hatMock := &hatMock{
 		je: je,
 		se: se,
 	}
+
+	reg1 := make(chan []byte)
+	reg2 := make(chan []byte)
+
+	client1 := n.Subscribe(reg1)
+	client2 := n.Subscribe(reg2)
 
 	done := make(chan bool)
 	defer close(done)
@@ -26,16 +39,25 @@ func TestControllerStart(t *testing.T) {
 		screenEvents:   se,
 		done:           done,
 		state:          s,
+		notifier:       n,
+		clientEvents:   ce,
 	}
 
 	y := s.Cursor.Y
 	x := s.Cursor.X
 
 	c.Start()
+
 	msg := <-se
 	if msg.CursorX != x {
 		t.Errorf("msg.CursorX should be %d but it's %d", x, msg.CursorX)
 	}
+
+	ce <- webapp.ClientEventRegistered(client1)
+	<-checkNotifications(t, reg1, x, y)
+	ce <- webapp.ClientEventRegistered(client2)
+	<-checkNotifications(t, reg2, x, y)
+
 	if msg.CursorY != y {
 		t.Errorf("msg.CursorY should be %d but it's %d", y, msg.CursorY)
 	}
@@ -45,28 +67,77 @@ func TestControllerStart(t *testing.T) {
 	if msg.CursorY != y+1 {
 		t.Errorf("msg.CursorY should be %d but it's %d", y+1, msg.CursorY)
 	}
+	<-checkNotifications(t, reg1, x, y+1)
+	<-checkNotifications(t, reg2, x, y+1)
 
 	hatMock.MoveUp()
 	msg = <-se
 	if msg.CursorY != y {
 		t.Errorf("msg.CursorY should be %d but it's %d", y, msg.CursorY)
 	}
+	<-checkNotifications(t, reg1, x, y)
+	<-checkNotifications(t, reg2, x, y)
 
 	hatMock.MoveRight()
 	msg = <-se
 	if msg.CursorX != x+1 {
 		t.Errorf("msg.CursorX should be %d but it's %d", x+1, msg.CursorY)
 	}
+	<-checkNotifications(t, reg1, x+1, y)
+	<-checkNotifications(t, reg2, x+1, y)
 
 	hatMock.MoveLeft()
 	msg = <-se
 	if msg.CursorY != x {
 		t.Errorf("msg.CursorX should be %d but it's %d", x, msg.CursorY)
 	}
+	<-checkNotifications(t, reg1, x, y)
+	<-checkNotifications(t, reg2, x, y)
 
 	hatMock.Press()
 	msg = <-se
 	if !msg.Screen[y][x] {
 		t.Errorf("msg.Screen[%d][%d] should be set", y, x)
 	}
+	<-checkNotifications(t, reg1, x, y, x, y)
+	<-checkNotifications(t, reg2, x, y, x, y)
+}
+
+func checkNotifications(t *testing.T, reg chan []byte, x uint8, y uint8, points ...uint8) chan bool {
+	doneCheckingNotifier := make(chan bool)
+	go func() {
+		defer close(doneCheckingNotifier)
+
+		msg := <-reg
+		webMsg, err := getCanvasFromMsg(msg)
+		if err != nil {
+			t.Fatal("getCanvasFromMsg", err)
+		}
+		if webMsg.Cursor.X != x {
+			t.Errorf("webMsg.Cursor.X should be %d but it's %d", x, webMsg.Cursor.X)
+		}
+		if webMsg.Cursor.Y != y {
+			t.Errorf("webMsg.Cursor.y should be %d but it's %d", y+1, webMsg.Cursor.Y)
+		}
+
+		if len(points) > 0 && len(points)%2 == 0 {
+			for i := 0; i < len(points); i += 2 {
+				px := points[i]
+				py := points[i+1]
+
+				if !webMsg.Canvas[py][px] {
+					t.Error("webMsg.Canvas[py][px] should be set")
+				}
+			}
+		}
+	}()
+	return doneCheckingNotifier
+}
+
+func getCanvasFromMsg(msg []byte) (*state.State, error) {
+	s := &state.State{}
+	if err := json.Unmarshal(msg, s); err != nil {
+		return nil, err
+	}
+	return s, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/nunnatsa/piHatDraw
 
 go 1.16
 
-require github.com/nathany/bobblehat v0.0.0-20170421151738-14b0d1b4643e
+require (
+	github.com/gorilla/websocket v1.4.2
+	github.com/nathany/bobblehat v0.0.0-20170421151738-14b0d1b4643e
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/nathany/bobblehat v0.0.0-20170421151738-14b0d1b4643e h1:laO0ulsXfuedAk+m0frxy+o7uaoclS9SsVTBCSl6bew=
 github.com/nathany/bobblehat v0.0.0-20170421151738-14b0d1b4643e/go.mod h1:rxS+MnnPI6N0Ia8dxXUxQBrpvCXvOsGF3kAsnNMlF4Y=

--- a/hat/hat.go
+++ b/hat/hat.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nathany/bobblehat/sense/screen"
 	"github.com/nathany/bobblehat/sense/screen/color"
 	"github.com/nathany/bobblehat/sense/stick"
+
 	"github.com/nunnatsa/piHatDraw/common"
 )
 

--- a/main.go
+++ b/main.go
@@ -1,14 +1,39 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/nunnatsa/piHatDraw/notifier"
+	"github.com/nunnatsa/piHatDraw/webapp"
 
 	"github.com/nunnatsa/piHatDraw/controller"
 )
 
 func main() {
-	control := controller.NewController()
-	<-control.Start()
 
-	fmt.Println("\nGood Bye!")
+	n := notifier.NewNotifier()
+
+	clientEvents := make(chan webapp.ClientEvent)
+	webApplication := webapp.NewWebApplication(n, 8080, clientEvents)
+
+	server := http.Server{Addr: ":8080", Handler: webApplication.GetMux()}
+
+	control := controller.NewController(n, clientEvents)
+	done := control.Start()
+	go func() {
+		<-done
+		if err := server.Shutdown(context.Background()); err != nil {
+			log.Fatalf("Failed to shutdown the server; %v", err)
+		}
+	}()
+
+	if err := server.ListenAndServe(); err != http.ErrServerClosed {
+		log.Panic(err)
+	} else {
+		fmt.Println("\nGood Bye!")
+	}
+
 }

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -1,0 +1,74 @@
+package notifier
+
+import (
+	"log"
+	"sync"
+	"sync/atomic"
+)
+
+type idProvider struct {
+	counter uint64
+}
+
+func newIdProvider() *idProvider {
+	return &idProvider{
+		counter: 0,
+	}
+}
+
+func (p *idProvider) getNextID() uint64 {
+	return atomic.AddUint64(&p.counter, 1)
+}
+
+type Notifier struct {
+	clientMap map[uint64]chan []byte
+	idp       *idProvider
+	lock      *sync.Mutex
+}
+
+func NewNotifier() *Notifier {
+	return &Notifier{
+		clientMap: make(map[uint64]chan []byte),
+		idp:       newIdProvider(),
+		lock:      &sync.Mutex{},
+	}
+}
+
+func (n *Notifier) Subscribe(ch chan []byte) uint64 {
+	id := n.idp.getNextID()
+	n.lock.Lock()
+	n.clientMap[id] = ch
+	n.lock.Unlock()
+
+	log.Println("register new client", id)
+
+	return id
+}
+
+func (n *Notifier) Unsubscribe(id uint64) {
+	log.Println("deregister client", id)
+	if ch, ok := n.clientMap[id]; ok {
+		n.lock.Lock()
+		delete(n.clientMap, id)
+		n.lock.Unlock()
+		close(ch)
+	}
+}
+
+func (n *Notifier) NotifyAll(data []byte) {
+	for _, subscriber := range n.clientMap {
+		go n.sendToSubscriber(subscriber, data)
+	}
+}
+
+func (n *Notifier) NotifyOne(id uint64, data []byte) {
+	if subscriber, ok := n.clientMap[id]; ok {
+		go n.sendToSubscriber(subscriber, data)
+	} else {
+		log.Printf("subscriber id %d was not found", id)
+	}
+}
+
+func (n Notifier) sendToSubscriber(subscriber chan<- []byte, data []byte) {
+	subscriber <- data
+}

--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -1,0 +1,114 @@
+package notifier
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestSubscribe(t *testing.T) {
+	const numSubscribers = 10
+	n := NewNotifier()
+	defer cleanup(n)
+	wg := &sync.WaitGroup{}
+
+	done := make(chan bool)
+	wg.Add(numSubscribers)
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	for i := 0; i < numSubscribers; i++ {
+		go func(wg *sync.WaitGroup) {
+			ch := make(chan []byte)
+			n.Subscribe(ch)
+			defer wg.Done()
+		}(wg)
+	}
+
+	<-done
+
+	if len(n.clientMap) != numSubscribers {
+		t.Errorf("Number of subscribers should be %d but it's %d", numSubscribers, len(n.clientMap))
+	}
+}
+
+func TestUnsubscribe(t *testing.T) {
+	n := NewNotifier()
+	ch := make(chan []byte)
+
+	id := n.Subscribe(ch)
+
+	n.Unsubscribe(id)
+
+	select {
+	case <-ch:
+	default:
+		t.Errorf("channel should be closed")
+	}
+
+	if len(n.clientMap) > 0 {
+		t.Errorf("clientMap should be empty")
+	}
+}
+
+func TestNotifyAll(t *testing.T) {
+	const numSubscribers = 10
+	n := NewNotifier()
+	defer cleanup(n)
+
+	channels := make([]chan []byte, numSubscribers)
+
+	for i := 0; i < numSubscribers; i++ {
+		ch := make(chan []byte)
+		channels[i] = ch
+		n.Subscribe(ch)
+	}
+
+	if len(n.clientMap) != numSubscribers {
+		t.Errorf("Number of subscribers should be %d but it's %d", numSubscribers, len(n.clientMap))
+	}
+
+	n.NotifyAll([]byte("message"))
+	time.Sleep(time.Millisecond * 10)
+
+	for i := 0; i < numSubscribers; i++ {
+		select {
+		case msg := <-channels[i]:
+			if string(msg) != "message" {
+				t.Errorf(`msg from channel #%d should be "message", but it's "%s"`, i, string(msg))
+			}
+		default:
+			t.Errorf("client %d Should received a message", i)
+
+		}
+	}
+}
+
+func TestNotifyOne(t *testing.T) {
+	n := NewNotifier()
+	defer cleanup(n)
+
+	ch := make(chan []byte)
+	id := n.Subscribe(ch)
+
+	n.NotifyOne(id, []byte("message"))
+	wait := time.After(time.Millisecond * 200)
+
+	select {
+	case msg := <-ch:
+		if string(msg) != "message" {
+			t.Errorf(`msg from channel should be "message", but it's "%s"`, string(msg))
+		}
+
+	case <-wait:
+		t.Error("client Should received a message")
+	}
+}
+
+func cleanup(n *Notifier) {
+	for id := range n.clientMap {
+		n.Unsubscribe(id)
+	}
+}

--- a/state/state.go
+++ b/state/state.go
@@ -16,12 +16,13 @@ const (
 type canvas [][]common.Color
 
 type cursor struct {
-	X, Y uint8
+	X uint8 `json:"x"`
+	Y uint8 `json:"y"`
 }
 
 type State struct {
-	Canvas canvas
-	Cursor cursor
+	Canvas canvas `json:"canvas,omitempty"`
+	Cursor cursor `json:"cursor,omitempty"`
 }
 
 func NewState() *State {

--- a/third-party-licenses/gorilla_websocket-LICENSE
+++ b/third-party-licenses/gorilla_websocket-LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2013 The Gorilla WebSocket Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/webapp/frontend.go
+++ b/webapp/frontend.go
@@ -1,0 +1,55 @@
+package webapp
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"html/template"
+	"log"
+	"net/http"
+	"os"
+)
+
+type indexPage []byte
+
+func (ip indexPage) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/html")
+	_, err := w.Write(ip)
+	if err != nil {
+		log.Println(err)
+	}
+}
+
+type indexPageParams struct {
+	Host string
+	Port uint16
+}
+
+//go:embed index.gohtml
+var indexTemplate embed.FS
+
+func newIndexPage(port uint16) indexPage {
+	indexPageFs, err := template.ParseFS(indexTemplate, "*.gohtml")
+	if err != nil {
+		log.Panicf("Can't parse index page; %v", err)
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		log.Panic(err)
+	}
+
+	hp := &indexPageParams{
+		Host: hostname,
+		Port: port,
+	}
+
+	buff := &bytes.Buffer{}
+	if err = indexPageFs.Execute(buff, hp); err != nil {
+		log.Panicf("Can't parse indexPage page; %v", err)
+	}
+
+	fmt.Printf("In your web browser, go to http://%s:%d\n", hostname, port)
+
+	return buff.Bytes()
+}

--- a/webapp/index.gohtml
+++ b/webapp/index.gohtml
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>RPiDraw</title>
+    <style>
+        html {
+            color: white;
+            background: black;
+        }
+        table, td, th {
+            border: 1px solid white;
+        }
+
+        td {
+            text-align:center;
+            vertical-align:middle
+        }
+
+        table {
+            border-collapse: collapse;
+            padding: 0;
+            margin: auto;
+        }
+
+        div#table_wrapper {
+            margin: auto;
+            padding: 0;
+        }
+
+        div#main {
+            margin: auto;
+            padding-left: 0;
+            padding-right: 0;
+        }
+
+        h1 {
+            text-align: center;
+            margin-bottom: 2em;
+        }
+
+        td {
+            width: 20px;
+            height: 20px;
+        }
+    </style>
+</head>
+<body>
+
+<div id="main">
+    <h1>Pi Sense HAT Draw</h1>
+    <div id="table_wrapper">
+        <table id="matrix">
+        </table>
+    </div>
+</div>
+
+<script type="text/javascript">
+
+    let cursorID
+
+    const socket = new WebSocket("ws://{{.Host}}:{{.Port}}/api/canvas/register");
+    socket.onmessage = function (e) {
+        const data = JSON.parse(e.data)
+        console.log(`Received new canvas: ${e.data}`)
+        let mt = document.getElementById("matrix")
+        while (mt.lastElementChild) {
+            mt.removeChild(mt.lastElementChild);
+        }
+
+        for ( let i = 0; i < data.canvas.length; i++ ) {
+            let line = data.canvas[i]
+            let tr = document.createElement("tr")
+            for (let j = 0; j < line.length; j++) {
+                let cell = line[j]
+                let td = document.createElement("td")
+                td.id = getCelId(j, i)
+                if ( cell ) {
+                    td.style.backgroundColor = "#ffffff"
+                }
+
+                tr.appendChild(td)
+            }
+            mt.appendChild(tr)
+        }
+
+        cursorID = getCelId(data.cursor.x, data.cursor.y)
+        const cursorElement = document.getElementById(cursorID)
+        cursorElement.style.color = reverseColor(cursorElement.style.backgroundColor)
+        cursorElement.innerText = 'x'
+    }
+
+    function getCelId(x, y) {
+        return `${x}`.padStart(2, '0') + '_' + `${y}`.padStart(2, '0')
+    }
+
+    function reverseColor(bg) {
+        const rx = /rgb\((\d+), (\d+), (\d+)\)/
+        let colors = bg.match(rx)
+        if (!colors) {
+            return 'rgb(255, 255, 255)'
+        }
+
+        const r = 255 - parseInt(colors[1])
+        const g = 255 - parseInt(colors[1])
+        const b = 255 - parseInt(colors[1])
+
+        return `rgb(${r}, ${g}, ${b}`
+    }
+</script>
+</body>
+</html>

--- a/webapp/websocket.go
+++ b/webapp/websocket.go
@@ -1,0 +1,72 @@
+package webapp
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/nunnatsa/piHatDraw/notifier"
+)
+
+var (
+	upgrader = websocket.Upgrader{
+		ReadBufferSize:  1500,
+		WriteBufferSize: 1500,
+	}
+)
+
+type ClientEvent interface{}
+
+type ClientEventRegistered uint64
+
+type WebApplication struct {
+	mux          *http.ServeMux
+	notifier     *notifier.Notifier
+	clientEvents chan<- ClientEvent
+}
+
+func (ca WebApplication) GetMux() *http.ServeMux {
+	return ca.mux
+}
+
+func NewWebApplication(mailbox *notifier.Notifier, port uint16, ch chan<- ClientEvent) *WebApplication {
+	mux := http.NewServeMux()
+	ca := &WebApplication{mux: mux, notifier: mailbox, clientEvents: ch}
+	mux.Handle("/", newIndexPage(port))
+	mux.HandleFunc("/api/canvas/register", ca.register)
+
+	return ca
+}
+
+func (ca WebApplication) register(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodGet {
+		conn, err := upgrader.Upgrade(w, r, nil) // error ignored for sake of simplicity
+		if err != nil {
+			log.Println("Error:", err)
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(err.Error()))
+
+			return
+		}
+
+		defer conn.Close()
+
+		subscription := make(chan []byte)
+
+		id := ca.notifier.Subscribe(subscription)
+		defer ca.notifier.Unsubscribe(id)
+		ca.clientEvents <- ClientEventRegistered(id)
+
+		for js := range subscription {
+			log.Printf("got event; updating client %d\n", id)
+			if err := conn.WriteMessage(websocket.TextMessage, js); err != nil {
+				log.Printf("failed to send message to the client %d: %v\n", id, err)
+				return
+			}
+		}
+		log.Println("Connection is closed")
+	} else {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}


### PR DESCRIPTION
Add a web-based display to be sync with the HAT LED display, using websockets and javascript.

Build an in-memory primitive publish-subscribe mechanism to keep the web clients in sync.

Signed-off-by: Nahshon Unna-Tsameret <nahsh.ut@gmail.com>