### PR TITLE
Use buffered channels for events, instead of using go routine to trigger them

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -25,8 +25,8 @@ type Controller struct {
 }
 
 func NewController(notifier *notifier.Notifier, clientEvents <-chan webapp.ClientEvent, canvasWidth uint8, canvasHeight uint8) *Controller {
-	je := make(chan hat.Event)
-	se := make(chan hat.DisplayMessage)
+	je := make(chan hat.Event, 1)
+	se := make(chan hat.DisplayMessage, 1)
 
 	return &Controller{
 		hat:            hat.NewHat(je, se),

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -23,18 +23,18 @@ func TestControllerStart(t *testing.T) {
 		canvasHeight = 24
 	)
 	s := state.NewState(canvasWidth, canvasHeight)
-	je := make(chan hat.Event)
-	se := make(chan hat.DisplayMessage)
+	je := make(chan hat.Event, 1)
+	se := make(chan hat.DisplayMessage, 1)
 	n := notifier.NewNotifier()
-	ce := make(chan webapp.ClientEvent)
+	ce := make(chan webapp.ClientEvent, 1)
 
 	hatMock := &hatMock{
 		je: je,
 		se: se,
 	}
 
-	reg1 := make(chan []byte)
-	reg2 := make(chan []byte)
+	reg1 := make(chan []byte, 1)
+	reg2 := make(chan []byte, 1)
 
 	client1 := n.Subscribe(reg1)
 	client2 := n.Subscribe(reg2)

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func main() {
 	n := notifier.NewNotifier()
 	defer n.Close()
 
-	clientEvents := make(chan webapp.ClientEvent)
+	clientEvents := make(chan webapp.ClientEvent, 1)
 	webApplication := webapp.NewWebApplication(n, port, clientEvents)
 
 	portStr := fmt.Sprintf(":%d", port)

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -57,13 +57,13 @@ func (n *Notifier) Unsubscribe(id uint64) {
 
 func (n *Notifier) NotifyAll(data []byte) {
 	for _, subscriber := range n.clientMap {
-		go n.sendToSubscriber(subscriber, data)
+		n.sendToSubscriber(subscriber, data)
 	}
 }
 
 func (n *Notifier) NotifyOne(id uint64, data []byte) {
 	if subscriber, ok := n.clientMap[id]; ok {
-		go n.sendToSubscriber(subscriber, data)
+		n.sendToSubscriber(subscriber, data)
 	} else {
 		log.Printf("subscriber id %d was not found", id)
 	}

--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -61,7 +61,7 @@ func TestNotifyAll(t *testing.T) {
 	channels := make([]chan []byte, numSubscribers)
 
 	for i := 0; i < numSubscribers; i++ {
-		ch := make(chan []byte)
+		ch := make(chan []byte, 1)
 		channels[i] = ch
 		n.Subscribe(ch)
 	}
@@ -90,7 +90,7 @@ func TestNotifyOne(t *testing.T) {
 	n := NewNotifier()
 	defer cleanup(n)
 
-	ch := make(chan []byte)
+	ch := make(chan []byte, 1)
 	id := n.Subscribe(ch)
 
 	n.NotifyOne(id, []byte("message"))

--- a/webapp/websocket.go
+++ b/webapp/websocket.go
@@ -78,7 +78,7 @@ func (ca WebApplication) register(w http.ResponseWriter, r *http.Request) {
 
 		defer conn.Close()
 
-		subscription := make(chan []byte)
+		subscription := make(chan []byte, 1)
 
 		id := ca.notifier.Subscribe(subscription)
 		defer ca.notifier.Unsubscribe(id)


### PR DESCRIPTION


Signed-off-by: Nahshon Unna-Tsameret <nahsh.ut@gmail.com>